### PR TITLE
Add ability to queue commands to run in succession

### DIFF
--- a/src/Contracts/Bus.php
+++ b/src/Contracts/Bus.php
@@ -24,6 +24,7 @@ interface Bus
      *
      * @param Command $command
      * @param string|null|Closure|Handler $handler
+     * @return $this
      */
     public function queue(Command $command, $handler = null);
 

--- a/src/Contracts/Bus.php
+++ b/src/Contracts/Bus.php
@@ -1,6 +1,8 @@
 <?php
 namespace HelpScout\Bus\Contracts;
 
+use Closure;
+
 /**
  * Interface Bus
  * @package HelpScout\Bus\Contracts
@@ -16,4 +18,21 @@ interface Bus
      * @return mixed
      */
     public function execute(Command $command, $handler = null);
+
+    /**
+     * Queue commands to run in sequence
+     *
+     * @param Command $command
+     * @param string|null|Closure|Handler $handler
+     */
+    public function queue(Command $command, $handler = null);
+
+    /**
+     * Execute all queued commands. When in strict mode,
+     * a failed command will stop subsequent executions.
+     *
+     * @param bool|false $strict
+     * @return void
+     */
+    public function executeAll($strict = false);
 }

--- a/src/DefaultCommandBus.php
+++ b/src/DefaultCommandBus.php
@@ -1,10 +1,12 @@
 <?php
 namespace HelpScout\Bus;
 
+use Closure;
 use HelpScout\Bus\Contracts\Bus;
 use HelpScout\Bus\Contracts\Command;
 use HelpScout\Bus\Contracts\Handler;
 use HelpScout\Bus\Contracts\Resolver;
+use SplQueue;
 
 /**
  * Class DefaultCommandBus
@@ -16,7 +18,12 @@ class DefaultCommandBus implements Bus
      * Resolver for locating and instantiating handlers
      * @var Resolver
      */
-    private $resolver;
+    protected $resolver;
+
+    /**
+     * @var SplQueue
+     */
+    protected $queue;
 
     /**
      * DefaultCommandBus constructor.
@@ -26,6 +33,7 @@ class DefaultCommandBus implements Bus
     public function __construct(Resolver $resolver)
     {
         $this->resolver = $resolver;
+        $this->queue = new SplQueue;
     }
 
     /**
@@ -56,6 +64,39 @@ class DefaultCommandBus implements Bus
     {
         $this->resolver = $resolver;
     }
-}
 
-/* End of file DefaultCommandBus.php */
+    /**
+     * Queue commands to run in sequence
+     *
+     * @param Command $command
+     * @param string|null|Closure|Handler $handler
+     */
+    public function queue(Command $command, $handler = null)
+    {
+        $this->queue->enqueue([$command, $handler]);
+    }
+
+    /**
+     * Execute all queued commands. When in strict mode,
+     * a failed command will stop subsequent executions.
+     *
+     * @param bool|false $strict
+     * @throws \Exception
+     */
+    public function executeAll($strict = false)
+    {
+        while (!$this->queue->isEmpty()) {
+            list($command, $handler) = $this->queue->dequeue();
+
+            try {
+                $this->execute($command, $handler);
+            } catch (\Exception $e) {
+                if ($strict) {
+                    throw $e;
+                }
+            }
+        }
+    }
+
+
+}

--- a/src/DefaultCommandBus.php
+++ b/src/DefaultCommandBus.php
@@ -70,10 +70,13 @@ class DefaultCommandBus implements Bus
      *
      * @param Command $command
      * @param string|null|Closure|Handler $handler
+     * @return $this
      */
     public function queue(Command $command, $handler = null)
     {
         $this->queue->enqueue([$command, $handler]);
+
+        return $this;
     }
 
     /**

--- a/tests/DefaultCommandBusTest.php
+++ b/tests/DefaultCommandBusTest.php
@@ -1,10 +1,14 @@
 <?php
 namespace HelpScout\Bus\Tests;
 
+use Exception;
 use HelpScout\Bus\Contracts\Command;
 use HelpScout\Bus\Contracts\Handler;
 use HelpScout\Bus\Contracts\Resolver;
 use HelpScout\Bus\DefaultCommandBus;
+use HelpScout\Bus\Tests\Assets\DummyCommand;
+use HelpScout\Bus\Tests\Assets\DummyHandler;
+use HelpScout\Bus\Tests\Assets\FooCommand;
 
 class DefaultCommandBusTest extends \PHPUnit_Framework_TestCase
 {
@@ -40,5 +44,73 @@ class DefaultCommandBusTest extends \PHPUnit_Framework_TestCase
         $bus->setResolver($newResolverMock);
 
         $this->assertSame($newResolverMock, $reflectionProperty->getValue($bus));
+    }
+
+    public function testQueueMethodEnqueuesCommand()
+    {
+        $resolverMock = $this->getMockBuilder(Resolver::class)->getMock();
+        $bus = new DefaultCommandBus($resolverMock);
+
+        $reflectionClass = new \ReflectionClass(DefaultCommandBus::class);
+        $reflectionProperty = $reflectionClass->getProperty('queue');
+        $reflectionProperty->setAccessible(true);
+
+        $queue = $reflectionProperty->getValue($bus);
+
+        $this->assertInstanceOf(\SplQueue::class, $queue);
+        $this->assertEquals(0, $queue->count());
+
+        $commandMock = $this->getMockBuilder(Command::class)->getMock();
+
+        $bus->queue($commandMock);
+
+        $this->assertEquals(1, $queue->count());
+    }
+
+    public function testExecuteAllExecutesQueuedCommands()
+    {
+        $handlerMock = $this->getMockBuilder(Handler::class)->getMock();
+        $handlerMock->expects($this->once())->method('handle');
+
+        $resolverMock = $this->getMockBuilder(Resolver::class)->getMock();
+        $resolverMock->method('resolve')->willReturn($handlerMock);
+        $bus = new DefaultCommandBus($resolverMock);
+
+        $commandMock = $this->getMockBuilder(Command::class)->getMock();
+
+        $bus->queue($commandMock, $handlerMock);
+
+        $bus->executeAll();
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function testExecuteAllStopsExecutionWhenSetToStrict()
+    {
+        $commandMock = $this->getMockBuilder(Command::class)->getMock();
+
+        $handlerMock = $this->getMockBuilder(Handler::class)->getMock();
+        $handlerMock->expects($this->once())->method('handle');
+
+        $errorHandlerMock = $this->getMockBuilder(Handler::class)->getMock();
+        $errorHandlerMock->expects($this->once())->method('handle')->willThrowException(new Exception);
+
+        $failedHandlerMock = $this->getMockBuilder(Handler::class)->getMock();
+        $failedHandlerMock->expects($this->never())->method('handle');
+
+        $resolverMock = $this->getMockBuilder(Resolver::class)->getMock();
+
+        $resolverMock->expects($this->any())
+            ->method('resolve')
+            ->will($this->onConsecutiveCalls($handlerMock, $errorHandlerMock));
+
+        $bus = new DefaultCommandBus($resolverMock);
+
+        $bus->queue($commandMock, $handlerMock);
+        $bus->queue($commandMock, $errorHandlerMock);
+        $bus->queue($commandMock, $failedHandlerMock);
+
+        $bus->executeAll(true);
     }
 }

--- a/tests/DefaultCommandBusTest.php
+++ b/tests/DefaultCommandBusTest.php
@@ -107,10 +107,9 @@ class DefaultCommandBusTest extends \PHPUnit_Framework_TestCase
 
         $bus = new DefaultCommandBus($resolverMock);
 
-        $bus->queue($commandMock, $handlerMock);
-        $bus->queue($commandMock, $errorHandlerMock);
-        $bus->queue($commandMock, $failedHandlerMock);
-
-        $bus->executeAll(true);
+        $bus->queue($commandMock, $handlerMock)
+            ->queue($commandMock, $errorHandlerMock)
+            ->queue($commandMock, $failedHandlerMock)
+            ->executeAll(true);
     }
 }


### PR DESCRIPTION
## Feature

This PR adds the ability to queue commands and execute them all one after the other.
## Solution

Queueing commands is simple using the `queue` command. Executing all commands is done with a final call to `executeAll`.

```
$bus = new HelpScout\Bus\DefaultCommandBus($resolver);

$bus->queue(new FirstCommand)
        ->queue(new SecondCommand)
        ->queue(new ThirdCommand)
        ->executeAll();
```

`queue` takes a required argument of the command to be executed, and an optional second argument of the handler to be used (same signature as `execute()`).

`executeAll` takes an optional boolean parameter. Calling `executeAll(true)` sets the execution in "strict" mode. Any commands that throw an exception in strict mode will halt the execution of subsequent commands. By default, this is set to `false`, thus allowing commands to execute and run from the queue regardless of whether the previous commands succeeded or failed.
## Impact

Minimal impact on existing functionality as this PR just _adds_ functionality and does not change existing code.
## Reviewers

@craig-davis & @davidstanley01 
