### PR TITLE
Add php-standards project, add composer commands for sniffing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,47 @@
+- repo: git@github.com:pre-commit/pre-commit-hooks
+  sha: ff65d01841ad012d0a9aa1dc451fc4539d8b7baf
+  hooks:
+  - id: check-json
+    stages: [commit]
+  - id: check-merge-conflict
+    stages: [commit]
+  - id: check-yaml
+    stages: [commit]
+  - id: end-of-file-fixer
+    stages: [commit]
+  - id: trailing-whitespace
+    stages: [commit]
+  - id: detect-private-key
+    stages: [commit]
+  - id: detect-aws-credentials
+    stages: [commit]
+- repo: git@github.com:hootsuite/pre-commit-php.git
+  sha: 1.1.0
+  hooks:
+  - id: php-lint-all
+    stages: [commit,push]
+  - id: php-unit
+    stages: [commit,push]
+  - id: php-cs
+    stages: [commit]
+    files: \.(php)$
+    args: [
+      '-p',
+      '--standard=vendor/helpscout/php-standards/HelpScout',
+      '--warning-severity=0',
+      '--ignore=examples'
+    ]
+- repo: git://github.com/Lucas-C/pre-commit-hooks
+  sha: b600798f8dacfcc29862e3d58367b89d3090c6a7
+  hooks:
+  - id: forbid-crlf
+    stages: [commit]
+  - id: forbid-tabs
+- repo: local
+  hooks:
+  - id: check-bash-syntax
+    stages: [commit]
+    name: Check Shell scripts syntax corectness
+    language: system
+    entry: bash -n
+    files: \.sh$

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ matrix:
     - php: 5.5
     - php: 5.6
     - php: 7.0
+  allow_failures:
+    - php: 5.5
 
 before_script:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
         "jakub-onderka/php-console-highlighter": "^0.3.2",
         "jakub-onderka/php-parallel-lint": "^0.9.2",
         "phpunit/php-code-coverage": "^4.0",
-        "phpunit/phpunit": "4.8.*",
         "phpunit/phpunit": "^5.3",
         "squizlabs/php_codesniffer": "^2.6"
     },

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,13 @@
         "php": ">=5.5.0"
     },
     "require-dev": {
+        "helpscout/php-standards": "dev-master",
+        "jakub-onderka/php-console-highlighter": "^0.3.2",
+        "jakub-onderka/php-parallel-lint": "^0.9.2",
+        "phpunit/php-code-coverage": "^4.0",
         "phpunit/phpunit": "4.8.*",
-        "phpunit/php-code-coverage": "2.2.*"
+        "phpunit/phpunit": "^5.3",
+        "squizlabs/php_codesniffer": "^2.6"
     },
     "autoload": {
         "psr-4": {
@@ -27,9 +32,18 @@
         }
     },
     "scripts": {
+        "post-install-cmd": [
+            "bash contrib/setup.sh"
+        ],
         "test": [
+            "@lint",
+            "@sniff",
             "@phpunit"
         ],
+        "lint": "vendor/bin/parallel-lint --exclude app --exclude vendor .",
+        "sniff": "vendor/bin/phpcs --standard=vendor/helpscout/php-standards/HelpScout --warning-severity=0 --extensions=php src tests",
+        "strict": "vendor/bin/phpcs --standard=vendor/helpscout/php-standards/HelpScout --extensions=php src tests",
+        "format": "vendor/bin/phpcbf --standard=vendor/helpscout/php-standards/HelpScout --extensions=php src tests",
         "phpunit": "vendor/bin/phpunit --verbose"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "f5955066389486a8ca413125a352863a",
+    "hash": "b22bfa5f66b4e14924b34eb59bf583d0",
     "content-hash": "b978c323c2458ac7e1d60290465dac5c",
     "packages": [],
     "packages-dev": [
@@ -68,12 +68,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/helpscout/php-standards.git",
-                "reference": "83746de557e78db44c121187e0f2d4f410c510a6"
+                "reference": "7ed5fc53d3af4c5cf6334d780e7fbf0270d48352"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/helpscout/php-standards/zipball/83746de557e78db44c121187e0f2d4f410c510a6",
-                "reference": "83746de557e78db44c121187e0f2d4f410c510a6",
+                "url": "https://api.github.com/repos/helpscout/php-standards/zipball/7ed5fc53d3af4c5cf6334d780e7fbf0270d48352",
+                "reference": "7ed5fc53d3af4c5cf6334d780e7fbf0270d48352",
                 "shasum": ""
             },
             "type": "library",
@@ -94,7 +94,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-05-06 16:58:39"
+            "time": "2016-06-15 14:24:55"
         },
         {
             "name": "jakub-onderka/php-console-color",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "b0a0693f7fdc79b9b436874c711e76cf",
-    "content-hash": "8021f5e3ace2bff16e6e14e279039ddc",
+    "hash": "f5955066389486a8ca413125a352863a",
+    "content-hash": "b978c323c2458ac7e1d60290465dac5c",
     "packages": [],
     "packages-dev": [
         {
@@ -63,6 +63,216 @@
             "time": "2015-06-14 21:17:01"
         },
         {
+            "name": "helpscout/php-standards",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/helpscout/php-standards.git",
+                "reference": "83746de557e78db44c121187e0f2d4f410c510a6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/helpscout/php-standards/zipball/83746de557e78db44c121187e0f2d4f410c510a6",
+                "reference": "83746de557e78db44c121187e0f2d4f410c510a6",
+                "shasum": ""
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Developers",
+                    "email": "developer@helpscout.net"
+                }
+            ],
+            "description": "Help Scout PHP Code Standards",
+            "homepage": "http://developer.helpscout.net/",
+            "keywords": [
+                "Help Scout",
+                "phpcs",
+                "standards"
+            ],
+            "time": "2016-05-06 16:58:39"
+        },
+        {
+            "name": "jakub-onderka/php-console-color",
+            "version": "0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/JakubOnderka/PHP-Console-Color.git",
+                "reference": "e0b393dacf7703fc36a4efc3df1435485197e6c1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/JakubOnderka/PHP-Console-Color/zipball/e0b393dacf7703fc36a4efc3df1435485197e6c1",
+                "reference": "e0b393dacf7703fc36a4efc3df1435485197e6c1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "jakub-onderka/php-code-style": "1.0",
+                "jakub-onderka/php-parallel-lint": "0.*",
+                "jakub-onderka/php-var-dump-check": "0.*",
+                "phpunit/phpunit": "3.7.*",
+                "squizlabs/php_codesniffer": "1.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JakubOnderka\\PhpConsoleColor": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jakub Onderka",
+                    "email": "jakub.onderka@gmail.com",
+                    "homepage": "http://www.acci.cz"
+                }
+            ],
+            "time": "2014-04-08 15:00:19"
+        },
+        {
+            "name": "jakub-onderka/php-console-highlighter",
+            "version": "v0.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/JakubOnderka/PHP-Console-Highlighter.git",
+                "reference": "7daa75df45242c8d5b75a22c00a201e7954e4fb5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/JakubOnderka/PHP-Console-Highlighter/zipball/7daa75df45242c8d5b75a22c00a201e7954e4fb5",
+                "reference": "7daa75df45242c8d5b75a22c00a201e7954e4fb5",
+                "shasum": ""
+            },
+            "require": {
+                "jakub-onderka/php-console-color": "~0.1",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "jakub-onderka/php-code-style": "~1.0",
+                "jakub-onderka/php-parallel-lint": "~0.5",
+                "jakub-onderka/php-var-dump-check": "~0.1",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "~1.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JakubOnderka\\PhpConsoleHighlighter": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jakub Onderka",
+                    "email": "acci@acci.cz",
+                    "homepage": "http://www.acci.cz/"
+                }
+            ],
+            "time": "2015-04-20 18:58:01"
+        },
+        {
+            "name": "jakub-onderka/php-parallel-lint",
+            "version": "v0.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/JakubOnderka/PHP-Parallel-Lint.git",
+                "reference": "2ead2e4043ab125bee9554f356e0a86742c2d4fa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/JakubOnderka/PHP-Parallel-Lint/zipball/2ead2e4043ab125bee9554f356e0a86742c2d4fa",
+                "reference": "2ead2e4043ab125bee9554f356e0a86742c2d4fa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "jakub-onderka/php-console-highlighter": "~0.3",
+                "nette/tester": "~1.3"
+            },
+            "suggest": {
+                "jakub-onderka/php-console-highlighter": "Highlight syntax in code snippet"
+            },
+            "bin": [
+                "parallel-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "./"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jakub Onderka",
+                    "email": "jakub.onderka@gmail.com"
+                }
+            ],
+            "description": "This tool check syntax of PHP files about 20x faster than serial check.",
+            "homepage": "https://github.com/JakubOnderka/PHP-Parallel-Lint",
+            "time": "2015-12-15 10:42:16"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "a8773992b362b58498eed24bf85005f363c34771"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/a8773992b362b58498eed24bf85005f363c34771",
+                "reference": "a8773992b362b58498eed24bf85005f363c34771",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "doctrine/collections": "1.*",
+                "phpunit/phpunit": "~4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "homepage": "https://github.com/myclabs/DeepCopy",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2015-11-20 12:04:31"
+        },
+        {
             "name": "phpdocumentor/reflection-common",
             "version": "1.0",
             "source": {
@@ -118,22 +328,22 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.0.2",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "45ada3e3fd09789fbfbd6d65b3f0901f0030dc61"
+                "reference": "9270140b940ff02e58ec577c237274e92cd40cdd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/45ada3e3fd09789fbfbd6d65b3f0901f0030dc61",
-                "reference": "45ada3e3fd09789fbfbd6d65b3f0901f0030dc61",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/9270140b940ff02e58ec577c237274e92cd40cdd",
+                "reference": "9270140b940ff02e58ec577c237274e92cd40cdd",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5",
                 "phpdocumentor/reflection-common": "^1.0@dev",
-                "phpdocumentor/type-resolver": "^0.1.5",
+                "phpdocumentor/type-resolver": "^0.2.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
@@ -159,20 +369,20 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-06-06 06:44:13"
+            "time": "2016-06-10 09:48:41"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.1.8",
+            "version": "0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "9891754231e55d42f0d16988ffb799af39f31a12"
+                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9891754231e55d42f0d16988ffb799af39f31a12",
-                "reference": "9891754231e55d42f0d16988ffb799af39f31a12",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/b39c7a5b194f9ed7bd0dd345c751007a41862443",
+                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443",
                 "shasum": ""
             },
             "require": {
@@ -181,7 +391,7 @@
             },
             "require-dev": {
                 "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^5.2"
+                "phpunit/phpunit": "^5.2||^4.8.24"
             },
             "type": "library",
             "extra": {
@@ -206,7 +416,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-03-28 10:02:29"
+            "time": "2016-06-10 07:14:17"
         },
         {
             "name": "phpspec/prophecy",
@@ -272,39 +482,40 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.2.4",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979"
+                "reference": "900370c81280cc0d942ffbc5912d80464eaee7e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/eabf68b476ac7d0f73793aada060f1c1a9bf8979",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/900370c81280cc0d942ffbc5912d80464eaee7e9",
+                "reference": "900370c81280cc0d942ffbc5912d80464eaee7e9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
+                "php": "^5.6 || ^7.0",
                 "phpunit/php-file-iterator": "~1.3",
                 "phpunit/php-text-template": "~1.2",
-                "phpunit/php-token-stream": "~1.3",
+                "phpunit/php-token-stream": "^1.4.2",
+                "sebastian/code-unit-reverse-lookup": "~1.0",
                 "sebastian/environment": "^1.3.2",
-                "sebastian/version": "~1.0"
+                "sebastian/version": "~1.0|~2.0"
             },
             "require-dev": {
                 "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "~4"
+                "phpunit/phpunit": "^5.4"
             },
             "suggest": {
                 "ext-dom": "*",
-                "ext-xdebug": ">=2.2.1",
+                "ext-xdebug": ">=2.4.0",
                 "ext-xmlwriter": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2.x-dev"
+                    "dev-master": "4.0.x-dev"
                 }
             },
             "autoload": {
@@ -330,7 +541,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:47:00"
+            "time": "2016-06-03 05:03:56"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -515,16 +726,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.26",
+            "version": "5.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "fc1d8cd5b5de11625979125c5639347896ac2c74"
+                "reference": "744a50838ef373be00fb658ce9544905cf587c17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/fc1d8cd5b5de11625979125c5639347896ac2c74",
-                "reference": "fc1d8cd5b5de11625979125c5639347896ac2c74",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/744a50838ef373be00fb658ce9544905cf587c17",
+                "reference": "744a50838ef373be00fb658ce9544905cf587c17",
                 "shasum": ""
             },
             "require": {
@@ -533,20 +744,26 @@
                 "ext-pcre": "*",
                 "ext-reflection": "*",
                 "ext-spl": "*",
-                "php": ">=5.3.3",
+                "myclabs/deep-copy": "~1.3",
+                "php": "^5.6 || ^7.0",
                 "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "~2.1",
+                "phpunit/php-code-coverage": "^4.0",
                 "phpunit/php-file-iterator": "~1.4",
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "~2.3",
+                "phpunit/phpunit-mock-objects": "^3.2",
                 "sebastian/comparator": "~1.1",
                 "sebastian/diff": "~1.2",
-                "sebastian/environment": "~1.3",
+                "sebastian/environment": "^1.3 || ^2.0",
                 "sebastian/exporter": "~1.2",
                 "sebastian/global-state": "~1.0",
-                "sebastian/version": "~1.0",
+                "sebastian/object-enumerator": "~1.0",
+                "sebastian/resource-operations": "~1.0",
+                "sebastian/version": "~1.0|~2.0",
                 "symfony/yaml": "~2.1|~3.0"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "3.0.2"
             },
             "suggest": {
                 "phpunit/php-invoker": "~1.1"
@@ -557,7 +774,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.8.x-dev"
+                    "dev-master": "5.4.x-dev"
                 }
             },
             "autoload": {
@@ -583,30 +800,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-05-17 03:09:28"
+            "time": "2016-06-15 07:20:05"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.8",
+            "version": "3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983"
+                "reference": "b13d0d9426ced06958bd32104653526a6c998a52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ac8e7a3db35738d56ee9a76e78a4e03d97628983",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/b13d0d9426ced06958bd32104653526a6c998a52",
+                "reference": "b13d0d9426ced06958bd32104653526a6c998a52",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
-                "php": ">=5.3.3",
-                "phpunit/php-text-template": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-text-template": "^1.2",
+                "sebastian/exporter": "^1.2"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^5.4"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -614,7 +834,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3.x-dev"
+                    "dev-master": "3.2.x-dev"
                 }
             },
             "autoload": {
@@ -639,7 +859,52 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02 06:51:40"
+            "time": "2016-06-12 07:37:26"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
+                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2016-02-13 06:45:14"
         },
         {
             "name": "sebastian/comparator",
@@ -925,6 +1190,52 @@
             "time": "2015-10-12 03:26:01"
         },
         {
+            "name": "sebastian/object-enumerator",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/d4ca2fb70344987502567bc50081c03e6192fb26",
+                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "sebastian/recursion-context": "~1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2016-01-28 13:25:10"
+        },
+        {
             "name": "sebastian/recursion-context",
             "version": "1.0.2",
             "source": {
@@ -978,20 +1289,70 @@
             "time": "2015-11-11 19:50:13"
         },
         {
-            "name": "sebastian/version",
-            "version": "1.0.6",
+            "name": "sebastian/resource-operations",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=5.6.0"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2015-07-28 20:34:47"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5",
+                "reference": "c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -1010,20 +1371,98 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2016-02-04 12:56:52"
         },
         {
-            "name": "symfony/yaml",
-            "version": "v3.1.0",
+            "name": "squizlabs/php_codesniffer",
+            "version": "2.6.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "eca51b7b65eb9be6af88ad7cc91685f1556f5c9a"
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "fb72ed32f8418db5e7770be1653e62e0d6f5dd3d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/eca51b7b65eb9be6af88ad7cc91685f1556f5c9a",
-                "reference": "eca51b7b65eb9be6af88ad7cc91685f1556f5c9a",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/fb72ed32f8418db5e7770be1653e62e0d6f5dd3d",
+                "reference": "fb72ed32f8418db5e7770be1653e62e0d6f5dd3d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "bin": [
+                "scripts/phpcs",
+                "scripts/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "CodeSniffer.php",
+                    "CodeSniffer/CLI.php",
+                    "CodeSniffer/Exception.php",
+                    "CodeSniffer/File.php",
+                    "CodeSniffer/Fixer.php",
+                    "CodeSniffer/Report.php",
+                    "CodeSniffer/Reporting.php",
+                    "CodeSniffer/Sniff.php",
+                    "CodeSniffer/Tokens.php",
+                    "CodeSniffer/Reports/",
+                    "CodeSniffer/Tokenizers/",
+                    "CodeSniffer/DocGenerators/",
+                    "CodeSniffer/Standards/AbstractPatternSniff.php",
+                    "CodeSniffer/Standards/AbstractScopeSniff.php",
+                    "CodeSniffer/Standards/AbstractVariableSniff.php",
+                    "CodeSniffer/Standards/IncorrectPatternException.php",
+                    "CodeSniffer/Standards/Generic/Sniffs/",
+                    "CodeSniffer/Standards/MySource/Sniffs/",
+                    "CodeSniffer/Standards/PEAR/Sniffs/",
+                    "CodeSniffer/Standards/PSR1/Sniffs/",
+                    "CodeSniffer/Standards/PSR2/Sniffs/",
+                    "CodeSniffer/Standards/Squiz/Sniffs/",
+                    "CodeSniffer/Standards/Zend/Sniffs/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2016-05-30 22:24:32"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "c5a7e7fc273c758b92b85dcb9c46149ccda89623"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/c5a7e7fc273c758b92b85dcb9c46149ccda89623",
+                "reference": "c5a7e7fc273c758b92b85dcb9c46149ccda89623",
                 "shasum": ""
             },
             "require": {
@@ -1059,7 +1498,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-05-26 21:46:24"
+            "time": "2016-06-14 11:18:07"
         },
         {
             "name": "webmozart/assert",
@@ -1113,11 +1552,13 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "helpscout/php-standards": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.4.0"
+        "php": ">=5.5.0"
     },
     "platform-dev": []
 }

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,14 @@
+Bus
+================================================================================
+> Contribution Guidelines
+
+We use [pre-commit by Yelp][yelp] to handle code linting, security checks, and
+running our tests pre-push. We would appreciate it if you used this tool before
+committing to the project.
+
+We use [our own published Help Scout standards][standards]. These are PSR2 plus
+a small collection of other preferences. Our code is PSR2 compliant, but not
+all PSR2 code is Help Scout compliant.
+
+[yelp]: http://pre-commit.com/
+[standards]: https://github.com/helpscout/php-standards

--- a/contrib/setup.sh
+++ b/contrib/setup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# Help Scout Contribution Tooling
+# ==============================================================================
+# Setup our pre-commit hooks if the tool is available
+#
+command -v pre-commit >/dev/null 2>&1 || {
+    echo ""
+    echo "We'd like for you to consider running our pre-commit hooks. To do so, you'll"
+    echo "need to install the pre-commit tool from http://pre-commit.com/"
+    echo "and then run 'pre-commit install' in this directory. Check out the"
+    echo ".pre-commit-config.yaml file to learn more about our QA checks."
+    exit 0;
+}
+echo ""
+echo "Thank you for running pre-commit!. Installing the Help Scout Hooks"
+echo "for this repo."
+echo ""
+pre-commit install --hook-type pre-commit
+pre-commit install --hook-type pre-push

--- a/src/ClosureHandler.php
+++ b/src/ClosureHandler.php
@@ -6,12 +6,14 @@ use HelpScout\Bus\Contracts\Handler;
 
 /**
  * Class ClosureHandler
+ *
  * @package HelpScout\Bus
  */
 class ClosureHandler implements Handler
 {
     /**
      * Closure
+     *
      * @var callable
      */
     private $closure;

--- a/src/Contracts/Bus.php
+++ b/src/Contracts/Bus.php
@@ -5,6 +5,7 @@ use Closure;
 
 /**
  * Interface Bus
+ *
  * @package HelpScout\Bus\Contracts
  */
 interface Bus
@@ -22,8 +23,9 @@ interface Bus
     /**
      * Queue commands to run in sequence
      *
-     * @param Command $command
+     * @param Command                     $command
      * @param string|null|Closure|Handler $handler
+     *
      * @return $this
      */
     public function queue(Command $command, $handler = null);
@@ -32,7 +34,8 @@ interface Bus
      * Execute all queued commands. When in strict mode,
      * a failed command will stop subsequent executions.
      *
-     * @param bool|false $strict
+     * @param boolean|false $strict
+     *
      * @return void
      */
     public function executeAll($strict = false);

--- a/src/Contracts/Command.php
+++ b/src/Contracts/Command.php
@@ -3,6 +3,9 @@ namespace HelpScout\Bus\Contracts;
 
 /**
  * Interface Command
+ *
  * @package HelpScout\Bus\Contracts
  */
-interface Command {}
+interface Command
+{
+}

--- a/src/Contracts/Handler.php
+++ b/src/Contracts/Handler.php
@@ -3,6 +3,7 @@ namespace HelpScout\Bus\Contracts;
 
 /**
  * Interface Handler
+ *
  * @package HelpScout\Bus\Contracts
  */
 interface Handler

--- a/src/Contracts/Resolver.php
+++ b/src/Contracts/Resolver.php
@@ -3,6 +3,7 @@ namespace HelpScout\Bus\Contracts;
 
 /**
  * Interface Resolver
+ *
  * @package HelpScout\Bus\Contracts
  */
 interface Resolver

--- a/src/Contracts/Translator.php
+++ b/src/Contracts/Translator.php
@@ -3,6 +3,7 @@ namespace HelpScout\Bus\Contracts;
 
 /**
  * Interface Translator
+ *
  * @package HelpScout\Bus\Contracts
  */
 interface Translator

--- a/src/DefaultCommandBus.php
+++ b/src/DefaultCommandBus.php
@@ -10,12 +10,14 @@ use SplQueue;
 
 /**
  * Class DefaultCommandBus
+ *
  * @package HelpScout\Bus
  */
 class DefaultCommandBus implements Bus
 {
     /**
      * Resolver for locating and instantiating handlers
+     *
      * @var Resolver
      */
     protected $resolver;
@@ -33,7 +35,7 @@ class DefaultCommandBus implements Bus
     public function __construct(Resolver $resolver)
     {
         $this->resolver = $resolver;
-        $this->queue = new SplQueue;
+        $this->queue    = new SplQueue;
     }
 
     /**
@@ -48,6 +50,7 @@ class DefaultCommandBus implements Bus
     {
         /**
          * The correct handler for the given command
+         *
          * @var Handler $handler
          */
         $handler = $this->resolver->resolve($command, $handler);
@@ -59,6 +62,8 @@ class DefaultCommandBus implements Bus
      * Replace the current Resolver with a new instance
      *
      * @param Resolver $resolver
+     *
+     * @return void
      */
     public function setResolver(Resolver $resolver)
     {
@@ -68,8 +73,9 @@ class DefaultCommandBus implements Bus
     /**
      * Queue commands to run in sequence
      *
-     * @param Command $command
+     * @param Command                     $command
      * @param string|null|Closure|Handler $handler
+     *
      * @return $this
      */
     public function queue(Command $command, $handler = null)
@@ -83,7 +89,9 @@ class DefaultCommandBus implements Bus
      * Execute all queued commands. When in strict mode,
      * a failed command will stop subsequent executions.
      *
-     * @param bool|false $strict
+     * @param boolean|false $strict
+     *
+     * @return void
      * @throws \Exception
      */
     public function executeAll($strict = false)
@@ -100,6 +108,4 @@ class DefaultCommandBus implements Bus
             }
         }
     }
-
-
 }

--- a/src/DefaultResolver.php
+++ b/src/DefaultResolver.php
@@ -10,12 +10,14 @@ use HelpScout\Bus\Exceptions\CouldNotResolveHandlerException;
 
 /**
  * Class DefaultResolver
+ *
  * @package HelpScout\Bus
  */
 class DefaultResolver implements Resolver
 {
     /**
      * To locate an appropriate handler for a command
+     *
      * @var Translator
      */
     private $translator;
@@ -34,7 +36,7 @@ class DefaultResolver implements Resolver
      * Find an appropriate handler for a command
      *
      * @param Command $command
-     * @param mixed    $handler
+     * @param mixed   $handler
      *
      * @return null|ClosureHandler
      * @throws CouldNotResolveHandlerException

--- a/src/DependencyResolver.php
+++ b/src/DependencyResolver.php
@@ -5,6 +5,7 @@ use HelpScout\Bus\Contracts\Handler;
 
 /**
  * Class DefaultCommandBus
+ *
  * @package HelpScout\Bus
  */
 class DependencyResolver extends DefaultResolver
@@ -19,7 +20,7 @@ class DependencyResolver extends DefaultResolver
     protected function initClass($className)
     {
         // Use reflection to get the list of constructor dependencies
-        $class = new \ReflectionClass($className);
+        $class       = new \ReflectionClass($className);
         $constructor = $class->getConstructor();
 
         // if no constructor, pop smoke and move out!

--- a/src/DispatchesCommandsTrait.php
+++ b/src/DispatchesCommandsTrait.php
@@ -19,7 +19,10 @@ trait DispatchesCommandsTrait
      */
     public function dispatch(Command $command, $handler = null)
     {
-        $bus = new DefaultCommandBus(new DefaultResolver(new NameBasedTranslator));
+        $bus = new DefaultCommandBus(
+            new DefaultResolver(new NameBasedTranslator)
+        );
+
         return $bus->execute($command, $handler);
     }
 }

--- a/src/Exceptions/CouldNotResolveHandlerException.php
+++ b/src/Exceptions/CouldNotResolveHandlerException.php
@@ -1,4 +1,6 @@
 <?php
 namespace HelpScout\Bus\Exceptions;
 
-class CouldNotResolveHandlerException extends \Exception {}
+class CouldNotResolveHandlerException extends \Exception
+{
+}

--- a/src/Exceptions/HandlerNotRegisteredException.php
+++ b/src/Exceptions/HandlerNotRegisteredException.php
@@ -1,4 +1,6 @@
 <?php
 namespace HelpScout\Bus\Exceptions;
 
-class HandlerNotRegisteredException extends \Exception {}
+class HandlerNotRegisteredException extends \Exception
+{
+}

--- a/tests/ClosureHandlerTest.php
+++ b/tests/ClosureHandlerTest.php
@@ -10,11 +10,12 @@ class ClosureHandlerTest extends \PHPUnit_Framework_TestCase
     {
         $commandMock = $this->getMockBuilder(Command::class)->getMock();
 
-        $closureHandler = new ClosureHandler(function($command)
-        {
-            return $command;
-        });
+        $closureHandler = new ClosureHandler(
+            function ($command) {
+                return $command;
+            }
+        );
 
-        $this->assertSame($closureHandler->handle($commandMock), $commandMock);
+        self::assertSame($closureHandler->handle($commandMock), $commandMock);
     }
 }

--- a/tests/DefaultCommandBusTest.php
+++ b/tests/DefaultCommandBusTest.php
@@ -26,45 +26,45 @@ class DefaultCommandBusTest extends \PHPUnit_Framework_TestCase
 
         $bus = new DefaultCommandBus($resolverMock);
 
-        $this->assertEquals($bus->execute($commandMock), $testMessage);
+        self::assertEquals($bus->execute($commandMock), $testMessage);
     }
 
     public function testSetResolverOnBus()
     {
         $resolverMock = $this->getMockBuilder(Resolver::class)->getMock();
-        $bus = new DefaultCommandBus($resolverMock);
+        $bus          = new DefaultCommandBus($resolverMock);
 
-        $reflectionClass = new \ReflectionClass(DefaultCommandBus::class);
+        $reflectionClass    = new \ReflectionClass(DefaultCommandBus::class);
         $reflectionProperty = $reflectionClass->getProperty('resolver');
         $reflectionProperty->setAccessible(true);
 
-        $this->assertSame($resolverMock, $reflectionProperty->getValue($bus));
+        self::assertSame($resolverMock, $reflectionProperty->getValue($bus));
 
         $newResolverMock = $this->getMockBuilder(Resolver::class)->getMock();
         $bus->setResolver($newResolverMock);
 
-        $this->assertSame($newResolverMock, $reflectionProperty->getValue($bus));
+        self::assertSame($newResolverMock, $reflectionProperty->getValue($bus));
     }
 
     public function testQueueMethodEnqueuesCommand()
     {
         $resolverMock = $this->getMockBuilder(Resolver::class)->getMock();
-        $bus = new DefaultCommandBus($resolverMock);
+        $bus          = new DefaultCommandBus($resolverMock);
 
-        $reflectionClass = new \ReflectionClass(DefaultCommandBus::class);
+        $reflectionClass    = new \ReflectionClass(DefaultCommandBus::class);
         $reflectionProperty = $reflectionClass->getProperty('queue');
         $reflectionProperty->setAccessible(true);
 
         $queue = $reflectionProperty->getValue($bus);
 
-        $this->assertInstanceOf(\SplQueue::class, $queue);
-        $this->assertEquals(0, $queue->count());
+        self::assertInstanceOf(\SplQueue::class, $queue);
+        self::assertEquals(0, $queue->count());
 
         $commandMock = $this->getMockBuilder(Command::class)->getMock();
 
         $bus->queue($commandMock);
 
-        $this->assertEquals(1, $queue->count());
+        self::assertEquals(1, $queue->count());
     }
 
     public function testExecuteAllExecutesQueuedCommands()
@@ -85,6 +85,8 @@ class DefaultCommandBusTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Exception
+     *
+     * @return void
      */
     public function testExecuteAllStopsExecutionWhenSetToStrict()
     {
@@ -94,7 +96,9 @@ class DefaultCommandBusTest extends \PHPUnit_Framework_TestCase
         $handlerMock->expects($this->once())->method('handle');
 
         $errorHandlerMock = $this->getMockBuilder(Handler::class)->getMock();
-        $errorHandlerMock->expects($this->once())->method('handle')->willThrowException(new Exception);
+        $errorHandlerMock->expects($this->once())
+            ->method('handle')
+            ->willThrowException(new Exception);
 
         $failedHandlerMock = $this->getMockBuilder(Handler::class)->getMock();
         $failedHandlerMock->expects($this->never())->method('handle');

--- a/tests/DefaultResolverTest.php
+++ b/tests/DefaultResolverTest.php
@@ -56,7 +56,7 @@ class DefaultResolverTest extends \PHPUnit_Framework_TestCase
     public function testReturnHandlerFromString()
     {
         self::assertInstanceOf(
-            'DummyHandler',
+            DummyHandler::class,
             $this->resolver->resolve($this->commandMock, DummyHandler::class)
         );
     }
@@ -68,7 +68,7 @@ class DefaultResolverTest extends \PHPUnit_Framework_TestCase
         };
 
         self::assertInstanceOf(
-            'ClosureHandler',
+            ClosureHandler::class,
             $this->resolver->resolve($this->commandMock, $handler)
         );
     }
@@ -76,13 +76,13 @@ class DefaultResolverTest extends \PHPUnit_Framework_TestCase
     public function testReturnTranslatedHandler()
     {
         self::assertInstanceOf(
-            'DummyHandler',
+            DummyHandler::class,
             $this->resolver->resolve($this->commandMock)
         );
     }
 
     /**
-     * @expectedException CouldNotResolveHandlerException
+     * @expectedException \HelpScout\Bus\Exceptions\CouldNotResolveHandlerException
      *
      * @return void
      */

--- a/tests/DefaultResolverTest.php
+++ b/tests/DefaultResolverTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace HelpScout\Bus\Tests;
 
+use HelpScout\Bus\Contracts\Resolver;
 use HelpScout\Bus\Exceptions\CouldNotResolveHandlerException;
 use HelpScout\Bus\Tests\Assets\DummyHandler;
 use HelpScout\Bus\Contracts\Command;
@@ -11,15 +12,32 @@ use HelpScout\Bus\DefaultResolver;
 
 class DefaultResolverTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * Mock of a command class
+     *
+     * @var mixed
+     */
     private $commandMock;
+
+    /**
+     * Mock of a translator class
+     *
+     * @var mixed
+     */
     private $translatorMock;
+
+    /**
+     * Default Resolver
+     *
+     * @var Resolver
+     */
     private $resolver;
 
     public function setUp()
     {
         parent::setUp();
 
-        $this->commandMock = $this->getMockBuilder(Command::class)->getMock();
+        $this->commandMock    = $this->getMockBuilder(Command::class)->getMock();
         $this->translatorMock = $this->getMockBuilder(Translator::class)->getMock();
         $this->translatorMock->method('translate')->willReturn(DummyHandler::class);
         $this->resolver = new DefaultResolver($this->translatorMock);
@@ -29,32 +47,50 @@ class DefaultResolverTest extends \PHPUnit_Framework_TestCase
     {
         $handlerMock = $this->getMockBuilder(Handler::class)->getMock();
 
-        $this->assertSame($handlerMock, $this->resolver->resolve($this->commandMock, $handlerMock));
+        self::assertSame(
+            $handlerMock,
+            $this->resolver->resolve($this->commandMock, $handlerMock)
+        );
     }
 
     public function testReturnHandlerFromString()
     {
-        $this->assertTrue($this->resolver->resolve($this->commandMock, DummyHandler::class) instanceof DummyHandler);
+        self::assertInstanceOf(
+            'DummyHandler',
+            $this->resolver->resolve($this->commandMock, DummyHandler::class)
+        );
     }
 
     public function testReturnClosureHandler()
     {
-        $handler = function(){};
+        $handler = function () {
+            // noop
+        };
 
-        $this->assertTrue($this->resolver->resolve($this->commandMock, $handler) instanceof ClosureHandler);
+        self::assertInstanceOf(
+            'ClosureHandler',
+            $this->resolver->resolve($this->commandMock, $handler)
+        );
     }
 
     public function testReturnTranslatedHandler()
     {
-        $this->assertTrue($this->resolver->resolve($this->commandMock) instanceof DummyHandler);
+        self::assertInstanceOf(
+            'DummyHandler',
+            $this->resolver->resolve($this->commandMock)
+        );
     }
 
     /**
-     * @expectedException \HelpScout\Bus\Exceptions\CouldNotResolveHandlerException
+     * @expectedException CouldNotResolveHandlerException
+     *
+     * @return void
      */
     public function testResolverThrowsException()
     {
-        $this->translatorMock->method('translate')->willThrowException(new CouldNotResolveHandlerException);
+        $this->translatorMock
+            ->method('translate')
+            ->willThrowException(new CouldNotResolveHandlerException);
 
         $this->resolver->resolve($this->commandMock);
     }

--- a/tests/DependencyResolverTest.php
+++ b/tests/DependencyResolverTest.php
@@ -12,15 +12,17 @@ class DependencyResolverTest extends \PHPUnit_Framework_TestCase
 {
     public function testResolverInstantiatesDependencies()
     {
-        $translatorMock = $this->getMockBuilder(Translator::class)->getMock();
-        $commandMock = $this->getMockBuilder(Command::class)->getMock();
+        $translatorMock     = $this->getMockBuilder(Translator::class)->getMock();
+        $commandMock        = $this->getMockBuilder(Command::class)->getMock();
         $dependencyResolver = new DependencyResolver($translatorMock);
 
-        /** @var Foo $foo */
+        /**
+         * @var Foo $foo
+         */
         $foo = $dependencyResolver->resolve($commandMock, Foo::class);
 
-        $this->assertInstanceOf(Foo::class, $foo);
-        $this->assertInstanceOf(Bar::class, $foo->bar);
-        $this->assertInstanceOf(Baz::class, $foo->bar->baz);
+        self::assertInstanceOf(Foo::class, $foo);
+        self::assertInstanceOf(Bar::class, $foo->bar);
+        self::assertInstanceOf(Baz::class, $foo->bar->baz);
     }
 }

--- a/tests/NameBasedTranslatorTest.php
+++ b/tests/NameBasedTranslatorTest.php
@@ -20,7 +20,7 @@ class NameBasedTranslatorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException HandlerNotRegisteredException
+     * @expectedException \HelpScout\Bus\Exceptions\HandlerNotRegisteredException
      *
      * @return void
      */

--- a/tests/NameBasedTranslatorTest.php
+++ b/tests/NameBasedTranslatorTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace HelpScout\Bus\Tests;
 
+use HelpScout\Bus\Exceptions\HandlerNotRegisteredException;
 use HelpScout\Bus\Tests\Assets\DummyCommand;
 use HelpScout\Bus\Tests\Assets\DummyHandler;
 use HelpScout\Bus\Tests\Assets\FooCommand;
@@ -12,11 +13,16 @@ class NameBasedTranslatorTest extends \PHPUnit_Framework_TestCase
     {
         $translator = new NameBasedTranslator;
 
-        $this->assertEquals($translator->translate(new DummyCommand), DummyHandler::class);
+        self::assertEquals(
+            $translator->translate(new DummyCommand),
+            DummyHandler::class
+        );
     }
 
     /**
-     * @expectedException \HelpScout\Bus\Exceptions\HandlerNotRegisteredException
+     * @expectedException HandlerNotRegisteredException
+     *
+     * @return void
      */
     public function testTranslatorThrowsExceptionWhenHandlerDoesNotExist()
     {

--- a/tests/WithDataTraitTest.php
+++ b/tests/WithDataTraitTest.php
@@ -7,21 +7,23 @@ class WithDataTraitTest extends \PHPUnit_Framework_TestCase
 {
     public function testWithDataSetsClassProperties()
     {
-        $command = FooCommand::withData([
+        $data    = [
             'prefix' => 'hello',
             'suffix' => 'world'
-        ]);
+        ];
+        $command = FooCommand::withData($data);
 
-        $this->assertEquals('hello', $command->prefix);
-        $this->assertEquals('world', $command->suffix);
+        self::assertEquals('hello', $command->prefix);
+        self::assertEquals('world', $command->suffix);
     }
 
     public function testWithDataSkipsNonPropertyValues()
     {
-        $command = $command = FooCommand::withData([
+        $data    = [
             'punctuation' => '!'
-        ]);
+        ];
+        $command = $command = FooCommand::withData($data);
 
-        $this->assertFalse(isset($command->punctuation));
+        self::assertFalse(isset($command->punctuation));
     }
 }

--- a/tests/assets/DummyCommand.php
+++ b/tests/assets/DummyCommand.php
@@ -3,4 +3,6 @@ namespace HelpScout\Bus\Tests\Assets;
 
 use HelpScout\Bus\Contracts\Command;
 
-class DummyCommand implements Command {}
+class DummyCommand implements Command
+{
+}

--- a/tests/assets/Foo.php
+++ b/tests/assets/Foo.php
@@ -4,6 +4,8 @@ namespace HelpScout\Bus\Tests\Assets;
 class Foo
 {
     /**
+     * Testing with a public property
+     *
      * @var Bar
      */
     public $bar;

--- a/tests/assets/FooCommand.php
+++ b/tests/assets/FooCommand.php
@@ -6,7 +6,18 @@ use HelpScout\Bus\WithDataTrait;
 
 class FooCommand implements Command
 {
+    /**
+     * Prefix for the command
+     *
+     * @var string
+     */
     public $prefix;
+
+    /**
+     * Suffix for the commands
+     *
+     * @var string
+     */
     public $suffix;
 
     use WithDataTrait;


### PR DESCRIPTION
**Closes Issue #2**
## Feature
- Add the [php-standards](https://github.com/helpscout/php-standards) to the project with our normal stack of composer commands
- Update the project to pass standards check
## Implementation

The files now pass the standards check. The strict check will still fail on some line lengths.

This adds the following commands:
- `composer lint`: run a php linter on all files for syntax errors
- `composer sniff`: run the code standards in error only mode (or with your local settings)
- `composer strict`: run the code standards with warnings converted to errors
- `composer format`: run `phpcbf` with the Help Scout standards for code formatting

In the unit tests, this converts:
- assertions to use the static calls to quiet down some PHPStorm linting errors
- convert several assertions to use `assertInstanceOf` in place of `assertTrue`

This also updates to a newer version of php-code-coverage, in prep for enabling coverage reports in Code Climate. Unfortunately, in order to do this, I had to add php55 to the Travis allowed failures list, as the reporter needs 56. I'll try to followup with another PR to address this.
